### PR TITLE
Assign unique icon to bunchy menu item

### DIFF
--- a/packages/malkovich/src/components/main.tsx
+++ b/packages/malkovich/src/components/main.tsx
@@ -54,7 +54,7 @@ const components = [
 
 // Map package names to icons
 const packageIcons: Record<string, string> = {
-    bunchy: 'cog_outline',
+    bunchy: 'refresh',
     common: 'settings',
     expressio: 'translate',
     malkovich: 'viewlist',


### PR DESCRIPTION
Update bunchy menu icon to `refresh` to better reflect its role as a hot-reload/build tool.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9f1386a-cc82-4c16-90cc-9f253fb622f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9f1386a-cc82-4c16-90cc-9f253fb622f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

