### PR TITLE
Update Pyrite documentation for clarity

### DIFF
--- a/packages/pyrite/TESTING.md
+++ b/packages/pyrite/TESTING.md
@@ -194,18 +194,7 @@ NODE_ENV=production bun service.ts start
 
 ### Configuration Requirements
 
-**Minimum `.pyriterc`:**
-```json
-{
-  "sfu": {
-    "url": "http://localhost:8443",
-    "path": "/path/to/galene/data"
-  }
-}
-```
-
-**Full `.pyriterc`:**
-See `.pyriterc.example` for all options
+Edit `~/.pyriterc` with your settings. See `.pyriterc.example` for all available options.
 
 ## Troubleshooting
 
@@ -277,8 +266,7 @@ curl http://localhost:8443/
 
 2. **Configure Pyrite**
    - Copy `.pyriterc.example` to `~/.pyriterc`
-   - Update `sfu.url` and `sfu.path`
-   - Add admin users
+   - Edit `~/.pyriterc` with your settings (see `.pyriterc.example` for all options)
 
 3. **Test basic flow**
    - Start Pyrite: `bun run dev`

--- a/packages/pyrite/docs/index.md
+++ b/packages/pyrite/docs/index.md
@@ -16,20 +16,6 @@ Pyrite provides a self-hosted video conferencing solution with:
 - **i18n support** - Multi-language interface (English, German, French, Dutch)
 - **Responsive design** - Works on desktop and mobile devices
 
-## Quick Start
-
-```bash
-# Install globally
-bunx @garage44/pyrite start
-
-# Or from source
-cd packages/pyrite
-bun install
-bun run dev
-```
-
-Access Pyrite at `http://localhost:3030` (default login: `admin/admin`).
-
 ## Getting Started
 
 ### Prerequisites
@@ -53,7 +39,7 @@ Create a `.pyriterc` file in your home directory:
 cp packages/pyrite/.pyriterc.example ~/.pyriterc
 ```
 
-Edit `~/.pyriterc` with your configuration. At minimum, configure:
+Edit `~/.pyriterc` with your configuration. See `.pyriterc.example` for all available options. At minimum, configure:
 
 - `sfu.path` - Path to Galène data directory
 - `sfu.url` - Galène HTTP endpoint (default: `http://localhost:8443`)
@@ -70,44 +56,18 @@ cd packages/pyrite
 bun run dev
 ```
 
+Access Pyrite at `http://localhost:3030` (default login: `admin/admin`).
+
 ## Configuration
 
 Pyrite uses the [rc](https://www.npmjs.com/package/rc) configuration pattern. Configuration is loaded from:
 
 1. Command-line arguments
 2. Environment variables (prefixed with `pyrite_`)
-3. `.pyriterc` file in your home directory
+3. `.pyriterc` file in your home directory (or `CONFIG_PATH` environment variable)
 4. Default values
 
-### Essential Configuration
-
-```json
-{
-  "listen": {
-    "host": "0.0.0.0",
-    "port": 3030
-  },
-  "sfu": {
-    "path": "/path/to/galene/data",
-    "url": "http://localhost:8443",
-    "admin": {
-      "username": "admin",
-      "password": "changeme"
-    }
-  },
-  "users": [
-    {
-      "username": "admin",
-      "password": "changeme",
-      "permissions": {
-        "op": true,
-        "present": true,
-        "record": true
-      }
-    }
-  ]
-}
-```
+Edit `~/.pyriterc` to customize settings. See `.pyriterc.example` for all available options.
 
 **Security Note**: Store `.pyriterc` with restricted permissions (`chmod 600 ~/.pyriterc`) as it contains passwords.
 
@@ -138,26 +98,14 @@ packages/pyrite/
 
 ### Development Workflow
 
-**Start development server** (with hot reload):
-
 ```bash
+# Development mode (with hot reload)
 bun run dev
-```
 
-This starts:
-- Bun.serve() backend on port 3030
-- Bunchy file watcher for hot reload
-- WebSocket server for real-time updates
-
-**Build for production**:
-
-```bash
+# Build for production
 bun run build
-```
 
-**Run production server**:
-
-```bash
+# Run production server
 bun run server
 ```
 


### PR DESCRIPTION
Update Pyrite documentation to remove redundant content and full config examples, directing users to `.pyriterc.example` instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee5e1480-e576-4955-9237-e84c45aa8821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee5e1480-e576-4955-9237-e84c45aa8821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

