### PR TITLE
Improve markdown code block contrast

### DIFF
--- a/packages/malkovich/src/components/markdown.css
+++ b/packages/malkovich/src/components/markdown.css
@@ -146,7 +146,7 @@
     background-color: var(--surface-2);
     border: 1px solid var(--surface-3);
     border-radius: var(--border-radius-s);
-    color: var(--primary-3);
+    color: var(--primary-5);
     font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
     font-size: 0.9em;
     overflow-wrap: break-word;
@@ -158,7 +158,7 @@
     background-color: var(--surface-1);
     border: 1px solid var(--surface-3);
     border-radius: var(--border-radius-d);
-    color: var(--surface-7);
+    color: var(--surface-8);
     font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
     font-size: var(--font-s);
     line-height: 1.6;


### PR DESCRIPTION
Improve contrast for code blocks and inline code in markdown pages.

The previous text colors for code blocks and inline code had low contrast against their respective backgrounds, making them difficult to read. This change updates the text colors to `var(--primary-5)` for inline code and `var(--surface-8)` for code blocks, significantly enhancing readability while maintaining design system consistency across themes.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ac0ff71-2f23-4f0c-9d9d-a212d1017750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ac0ff71-2f23-4f0c-9d9d-a212d1017750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

