### PR TITLE
Add project urls to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Modern web applications built with Bun, Preact, and DeepSignal.
 
 AI-powered i18n automation platform. Automates translation workflows using AI providers (DeepL, Claude) and exports translation runtime for frontend applications.
 
+**🌐 Live:** [expressio.garage44.org](https://expressio.garage44.org)
+
 ```bash
 bunx @garage44/expressio start
 # Login: admin/admin
@@ -22,6 +24,8 @@ bunx @garage44/expressio start
 ### Pyrite
 
 Video conferencing frontend for the [Galène](https://galene.org/) SFU. Self-hosted solution with multi-party video, screen sharing, and chat.
+
+**🌐 Live:** [pyrite.garage44.org](https://pyrite.garage44.org)
 
 ```bash
 cd packages/pyrite

--- a/packages/expressio/docs/index.md
+++ b/packages/expressio/docs/index.md
@@ -2,6 +2,8 @@
 
 AI-powered i18n automation tool. Automates translation workflows using AI providers (DeepL, Claude) while maintaining source-text control and code synchronization.
 
+**🌐 Live:** [expressio.garage44.org](https://expressio.garage44.org)
+
 Expressio is part of the **garage44/common** infrastructure, sharing the same tech stack as [Pyrite](../pyrite/) - Bun runtime, Preact frontend, DeepSignal state management, and Bunchy for development with HMR.
 
 ## What It Does

--- a/packages/malkovich/docs/index.md
+++ b/packages/malkovich/docs/index.md
@@ -2,6 +2,8 @@
 
 Platform documentation and deployment tool for the Garage44 monorepo. Provides unified documentation hub, component styleguide, and automated PR deployment system.
 
+**🌐 Live:** [garage44.org](https://garage44.org)
+
 ## Overview
 
 Malkovich serves as the central platform for:

--- a/packages/pyrite/docs/index.md
+++ b/packages/pyrite/docs/index.md
@@ -2,6 +2,8 @@
 
 Video conferencing platform built with Preact, DeepSignal, and Bun. Provides a modern web interface for the [Galène](https://galene.org/) SFU (Selective Forwarding Unit).
 
+**🌐 Live:** [pyrite.garage44.org](https://pyrite.garage44.org)
+
 Pyrite is part of the **garage44/common** infrastructure, sharing the same tech stack as [Expressio](../expressio/) - Bun runtime, Preact frontend, DeepSignal state management, and Bunchy for development.
 
 ## What It Does


### PR DESCRIPTION
Add public project URLs for Expressio, Pyrite, and Malkovich to documentation to improve discoverability.

---
<a href="https://cursor.com/background-agent?bcId=bc-b178580c-9844-40af-b86a-a437f3fa5a76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b178580c-9844-40af-b86a-a437f3fa5a76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

