### PR TITLE
Add root link to panel menu

### DIFF
--- a/packages/expressio/src/components/main/main.tsx
+++ b/packages/expressio/src/components/main/main.tsx
@@ -4,7 +4,7 @@ import {$t} from '@garage44/expressio'
 import {Config, WorkspaceSettings, WorkspaceTranslations} from '@/components/pages'
 import {Settings} from '@/components/settings/settings'
 import {AppLayout, FieldSelect, MenuGroup, MenuItem, Notifications, PanelMenu, Progress, UserMenu} from '@garage44/common/components'
-import {Router, getCurrentUrl, route} from 'preact-router'
+import {Link, Router, getCurrentUrl, route} from 'preact-router'
 import {mergeDeep} from '@garage44/common/lib/utils'
 import {Login} from '@/components/pages/login/login'
 import {deepSignal} from 'deepsignal'
@@ -87,6 +87,8 @@ export const Main = () => {
             menu={
                 <PanelMenu
                     collapsed={$s.panels.menu.collapsed}
+                    LinkComponent={Link}
+                    logoHref="/"
                     onCollapseChange={(collapsed) => {
                         $s.panels.menu.collapsed = collapsed
                     }}

--- a/packages/expressio/src/components/main/main.tsx
+++ b/packages/expressio/src/components/main/main.tsx
@@ -95,14 +95,14 @@ export const Main = () => {
                     navigation={
 
                         <MenuGroup collapsed={$s.panels.menu.collapsed}>
-                            {$s.profile.admin && <MenuItem
+                            <MenuItem
                                 active={$s.env.url === '/'}
                                 collapsed={$s.panels.menu.collapsed}
                                 href="/"
-                                icon="settings"
+                                icon="dashboard"
                                 iconType="info"
                                 text={$t(i18n.menu.settings)}
-                            />}
+                            />
                             <FieldSelect
                                 disabled={!$s.workspaces.length}
                                 help={$t(i18n.menu.workspaces.help)}


### PR DESCRIPTION
Add a link to the root page in the panel menu to provide easy navigation for all authenticated users.

---
<a href="https://cursor.com/background-agent?bcId=bc-13c61b1a-2077-40e6-a87f-e8eb7e49e2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13c61b1a-2077-40e6-a87f-e8eb7e49e2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

