### PR TITLE
Move and update panel menu collapse icon

### DIFF
--- a/packages/common/components/ui/panel-menu/panel-menu.css
+++ b/packages/common/components/ui/panel-menu/panel-menu.css
@@ -74,32 +74,11 @@
             }
         }
 
-        .collapse-toggle {
-            align-items: center;
-            background: transparent;
-            border: none;
-            color: var(--surface-6);
-            cursor: pointer;
-            display: flex;
-            height: var(--spacer-4);
-            justify-content: center;
-            padding: var(--spacer-05);
-            transition: color 0.2s ease;
-            width: var(--spacer-4);
-
-            &:hover {
-                color: var(--surface-8);
-            }
-
-            svg {
-                display: block;
-            }
-        }
     }
 
     /* Hide collapse toggle on mobile - mobile controls handle this */
     @media (max-width: 768px) {
-        header .collapse-toggle {
+        .content .collapse-toggle {
             display: none;
         }
     }
@@ -223,6 +202,30 @@
             padding: var(--spacer-1);
             width: 100%;
         }
+
+        .collapse-toggle {
+            align-items: center;
+            background: var(--surface-2);
+            border: none;
+            border-top: 1px solid var(--surface-3);
+            color: var(--surface-7);
+            cursor: pointer;
+            display: flex;
+            justify-content: center;
+            margin-top: auto;
+            padding: var(--spacer-1);
+            transition: all 0.2s ease;
+            width: 100%;
+
+            &:hover {
+                background: var(--surface-3);
+                color: var(--surface-8);
+            }
+
+            .c-icon {
+                display: block;
+            }
+        }
     }
 
     &.collapsed {
@@ -251,11 +254,13 @@
                     margin-top: var(--spacer-1);
                 }
             }
+
+            /* Collapse toggle remains visible when collapsed */
+            .collapse-toggle {
+                padding: var(--spacer-1);
+            }
         }
 
-        .collapse-toggle {
-            margin-left: auto;
-        }
     }
 
     /* Mobile styles - overlay menu */

--- a/packages/common/components/ui/panel-menu/panel-menu.tsx
+++ b/packages/common/components/ui/panel-menu/panel-menu.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames'
 import {ComponentChildren} from 'preact/hooks'
+import {Icon} from '../icon/icon'
 
 interface PanelMenuProps {
     actions?: ComponentChildren
@@ -83,17 +84,6 @@ export const PanelMenu = ({
         >
             <header>
                 {renderLogo()}
-                {onCollapseChange && (
-                    <button
-                        class="collapse-toggle"
-                        onClick={() => onCollapseChange(!collapsed)}
-                        aria-label={collapsed ? 'Expand panel' : 'Collapse panel'}
-                    >
-                        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                            <path d={collapsed ? 'M10 8l-4-4v8l4-4z' : 'M6 8l4-4v8l-4-4z'} />
-                        </svg>
-                    </button>
-                )}
             </header>
                 <div class="content">
                     {navigation && (
@@ -107,6 +97,19 @@ export const PanelMenu = ({
                         </div>
                     )}
                     {footer && <div class="footer">{footer}</div>}
+                    {onCollapseChange && (
+                        <button
+                            class="collapse-toggle"
+                            onClick={() => onCollapseChange(!collapsed)}
+                            aria-label={collapsed ? 'Expand panel' : 'Collapse panel'}
+                        >
+                            <Icon
+                                name={collapsed ? 'collapseright' : 'collapseleft'}
+                                size="d"
+                                type="info"
+                            />
+                        </button>
+                    )}
                 </div>
         </aside>
     )


### PR DESCRIPTION
Move the PanelMenu collapse toggle to the bottom of the panel and use a more prominent icon to improve visibility and usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-4aee7e47-e6f2-46a1-a9bb-4c8c4343e48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4aee7e47-e6f2-46a1-a9bb-4c8c4343e48f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

