### PR TITLE
Add channel settings tab and sync with Galene

### DIFF
--- a/packages/common/components/ui/settings/tabs/users-management.css
+++ b/packages/common/components/ui/settings/tabs/users-management.css
@@ -1,141 +1,91 @@
 .c-users-management-tab {
     display: flex;
     flex-direction: column;
-    gap: var(--spacer-2);
-    padding: var(--spacer-2);
-    min-height: 400px;
+    gap: var(--spacer-4);
 }
 
-.c-users-management-tab .loading,
-.c-users-management-tab .error {
-    padding: var(--spacer-2);
-    text-align: center;
-    border-radius: var(--radius-1);
-}
-
-.c-users-management-tab .error {
-    background: var(--error-surface);
-    color: var(--error-text);
-}
-
-.c-users-management-tab .actions-header {
-    display: flex;
-    justify-content: flex-start;
-    padding-bottom: var(--spacer-2);
-    border-bottom: 1px solid var(--border-1);
-}
-
-.c-users-management-tab .users-list {
-    /* CollectionView styles are in collection-view.css */
-}
-
-.c-users-management-tab .user-username-cell {
-    display: flex;
+.c-users-management-tab__header {
     align-items: center;
-    gap: var(--spacer-1);
+    display: flex;
+    justify-content: space-between;
+
+    h2 {
+        color: var(--surface-7);
+        font-size: var(--font-l);
+        font-weight: var(--font-weight-semibold, 600);
+        margin: 0;
+    }
 }
 
-.c-users-management-tab .user-icon {
-    width: 20px;
-    height: 20px;
-    color: var(--text-2);
-    flex-shrink: 0;
-}
-
-.c-users-management-tab .username {
-    font-weight: 500;
-    color: var(--text-1);
-    font-size: var(--font-d);
-}
-
-.c-users-management-tab .user-role-empty {
-    color: var(--text-3);
-    font-style: italic;
-}
-
-.c-users-management-tab .admin-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    background: var(--accent-surface);
-    color: var(--accent-text);
-    border-radius: var(--radius-0);
-    font-size: var(--font-f);
-    font-weight: 500;
-}
-
-/* Row actions are handled by CollectionView component */
-
-.c-users-management-tab .empty-state {
-    padding: var(--spacer-4);
-    text-align: center;
-    color: var(--text-2);
-    font-size: var(--font-d);
-}
-
-/* User Editor Styles */
-.c-users-management-tab .user-editor {
-    padding: var(--spacer-2);
-    background: var(--surface-1);
-    border: 1px solid var(--border-1);
-    border-radius: var(--radius-1);
-}
-
-.c-users-management-tab .user-editor h3 {
-    margin: 0 0 var(--spacer-2) 0;
-    font-size: var(--font-c);
-    color: var(--text-1);
-}
-
-.c-users-management-tab .form-group {
+.c-users-management-tab__list {
     display: flex;
     flex-direction: column;
-    gap: var(--spacer-1);
-    margin-bottom: var(--spacer-2);
+    gap: var(--spacer-2);
+}
 
-    &.checkbox {
-        flex-direction: row;
-        align-items: center;
+.c-users-management-tab__item {
+    background: var(--surface-2);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--spacer-1);
+    padding: var(--spacer-2);
+}
+
+.c-users-management-tab__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacer-2);
+}
+
+.c-users-management-tab__content {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+
+    h3 {
+        color: var(--surface-8);
+        font-size: var(--font-d);
+        font-weight: var(--font-weight-semibold, 600);
+        margin: 0 0 var(--spacer-1);
+    }
+
+    p {
+        color: var(--surface-6);
+        font-size: var(--font-s);
+        margin: 0;
     }
 }
 
-.c-users-management-tab .form-group label {
-    font-weight: 500;
-    font-size: var(--font-d);
-    color: var(--text-1);
-}
-
-.c-users-management-tab .form-group input[type="text"],
-.c-users-management-tab .form-group input[type="password"] {
-    padding: var(--spacer-1);
-    border: 1px solid var(--border-1);
-    border-radius: var(--radius-1);
-    background: var(--surface-0);
-    color: var(--text-1);
-    font-size: var(--font-d);
-    transition: all 0.2s ease;
-
-    &:focus {
-        outline: none;
-        border-color: var(--accent-border);
-        background: var(--surface-1);
-    }
-
-    &:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-}
-
-.c-users-management-tab .form-group input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
-}
-
-.c-users-management-tab .editor-actions {
+.c-users-management-tab__actions {
     display: flex;
     gap: var(--spacer-1);
-    margin-top: var(--spacer-2);
-    padding-top: var(--spacer-2);
-    border-top: 1px solid var(--border-1);
+}
+
+.c-users-management-tab__create-form {
+    background: var(--surface-2);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--spacer-1);
+    padding: var(--spacer-3);
+
+    h3 {
+        color: var(--surface-7);
+        font-size: var(--font-d);
+        font-weight: var(--font-weight-semibold, 600);
+        margin: 0 0 var(--spacer-2);
+    }
+}
+
+.c-users-management-tab__badge {
+    background: var(--info-3);
+    border-radius: var(--spacer-1);
+    color: var(--info-8);
+    display: inline-block;
+    font-size: var(--font-s);
+    font-weight: var(--font-weight-semibold, 600);
+    padding: var(--spacer-05) var(--spacer-1);
+}
+
+.c-users-management-tab__empty {
+    color: var(--surface-6);
+    padding: var(--spacer-4);
+    text-align: center;
 }

--- a/packages/common/components/ui/settings/tabs/users-management.css
+++ b/packages/common/components/ui/settings/tabs/users-management.css
@@ -2,90 +2,90 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacer-4);
-}
 
-.c-users-management-tab__header {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
+    .header {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
 
-    h2 {
-        color: var(--surface-7);
-        font-size: var(--font-l);
-        font-weight: var(--font-weight-semibold, 600);
-        margin: 0;
-    }
-}
-
-.c-users-management-tab__list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
-}
-
-.c-users-management-tab__item {
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--spacer-1);
-    padding: var(--spacer-2);
-}
-
-.c-users-management-tab__form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
-}
-
-.c-users-management-tab__content {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-
-    h3 {
-        color: var(--surface-8);
-        font-size: var(--font-d);
-        font-weight: var(--font-weight-semibold, 600);
-        margin: 0 0 var(--spacer-1);
+        h2 {
+            color: var(--surface-7);
+            font-size: var(--font-l);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0;
+        }
     }
 
-    p {
-        color: var(--surface-6);
+    .list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacer-2);
+    }
+
+    .item {
+        background: var(--surface-2);
+        border: 1px solid var(--surface-3);
+        border-radius: var(--spacer-1);
+        padding: var(--spacer-2);
+    }
+
+    .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacer-2);
+    }
+
+    .content {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
+
+        h3 {
+            color: var(--surface-8);
+            font-size: var(--font-d);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0 0 var(--spacer-1);
+        }
+
+        p {
+            color: var(--surface-6);
+            font-size: var(--font-s);
+            margin: 0;
+        }
+    }
+
+    .actions {
+        display: flex;
+        gap: var(--spacer-1);
+    }
+
+    .create-form {
+        background: var(--surface-2);
+        border: 1px solid var(--surface-3);
+        border-radius: var(--spacer-1);
+        padding: var(--spacer-3);
+
+        h3 {
+            color: var(--surface-7);
+            font-size: var(--font-d);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0 0 var(--spacer-2);
+        }
+    }
+
+    .badge {
+        background: var(--info-3);
+        border-radius: var(--spacer-1);
+        color: var(--info-8);
+        display: inline-block;
         font-size: var(--font-s);
-        margin: 0;
-    }
-}
-
-.c-users-management-tab__actions {
-    display: flex;
-    gap: var(--spacer-1);
-}
-
-.c-users-management-tab__create-form {
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--spacer-1);
-    padding: var(--spacer-3);
-
-    h3 {
-        color: var(--surface-7);
-        font-size: var(--font-d);
         font-weight: var(--font-weight-semibold, 600);
-        margin: 0 0 var(--spacer-2);
+        padding: var(--spacer-05) var(--spacer-1);
     }
-}
 
-.c-users-management-tab__badge {
-    background: var(--info-3);
-    border-radius: var(--spacer-1);
-    color: var(--info-8);
-    display: inline-block;
-    font-size: var(--font-s);
-    font-weight: var(--font-weight-semibold, 600);
-    padding: var(--spacer-05) var(--spacer-1);
-}
-
-.c-users-management-tab__empty {
-    color: var(--surface-6);
-    padding: var(--spacer-4);
-    text-align: center;
+    .empty {
+        color: var(--surface-6);
+        padding: var(--spacer-4);
+        text-align: center;
+    }
 }

--- a/packages/common/components/ui/settings/tabs/users-management.tsx
+++ b/packages/common/components/ui/settings/tabs/users-management.tsx
@@ -200,7 +200,7 @@ export function UsersManagement({
 
     return (
         <section class="c-users-management-tab">
-            <div class="c-users-management-tab__header">
+            <div class="header">
                 <h2>User Management</h2>
             </div>
 
@@ -209,9 +209,9 @@ export function UsersManagement({
             ) : (
                 <>
                     {state.editing === null && (
-                        <div class="c-users-management-tab__create-form">
+                        <div class="create-form">
                             <h3>Create New User</h3>
-                            <div class="c-users-management-tab__form">
+                            <div class="form">
                                 <FieldText
                                     model={state.formData.$username}
                                     label={$t('user.management.field.username') || 'Username'}
@@ -224,11 +224,11 @@ export function UsersManagement({
                                     placeholder={$t('user.management.placeholder.password') || 'Enter password'}
                                 />
                                 <FieldCheckbox
-                                    model={state.$formData.$admin}
+                                    model={state.formData.$admin}
                                     label={$t('user.management.field.admin') || 'Admin'}
                                     help={$t('user.management.field.admin_help') || 'Grant administrator privileges'}
                                 />
-                                <div class="c-users-management-tab__actions">
+                                <div class="actions">
                                     <Button
                                         icon="plus"
                                         label={$t('user.management.action.add_user') || 'Create User'}
@@ -240,11 +240,11 @@ export function UsersManagement({
                         </div>
                     )}
 
-                    <div class="c-users-management-tab__list">
+                    <div class="list">
                         {state.users.map((user) => (
-                            <div key={user.id} class="c-users-management-tab__item">
+                            <div key={user.id} class="item">
                                 {state.editing === user.id ? (
-                                    <div class="c-users-management-tab__form">
+                                    <div class="form">
                                         <FieldText
                                             model={state.formData.$username}
                                             label={$t('user.management.field.username') || 'Username'}
@@ -257,11 +257,11 @@ export function UsersManagement({
                                             placeholder={$t('user.management.placeholder.password_optional') || 'Leave empty to keep current password'}
                                         />
                                         <FieldCheckbox
-                                            model={state.$formData.$admin}
+                                            model={state.formData.$admin}
                                             label={$t('user.management.field.admin') || 'Admin'}
                                             help={$t('user.management.field.admin_help') || 'Grant administrator privileges'}
                                         />
-                                        <div class="c-users-management-tab__actions">
+                                        <div class="actions">
                                             <Button
                                                 icon="save"
                                                 label={$t('user.management.action.save') || 'Save'}
@@ -277,14 +277,14 @@ export function UsersManagement({
                                         </div>
                                     </div>
                                 ) : (
-                                    <div class="c-users-management-tab__content">
+                                    <div class="content">
                                         <div>
                                             <h3>{user.username}</h3>
                                             {user.permissions?.admin && (
-                                                <p class="c-users-management-tab__badge">Admin</p>
+                                                <p class="badge">Admin</p>
                                             )}
                                         </div>
-                                        <div class="c-users-management-tab__actions">
+                                        <div class="actions">
                                             <Button
                                                 icon="edit"
                                                 onClick={() => startEdit(user)}
@@ -304,7 +304,7 @@ export function UsersManagement({
                             </div>
                         ))}
                         {state.users.length === 0 && (
-                            <div class="c-users-management-tab__empty">
+                            <div class="empty">
                                 <p>No users yet. Create your first user above.</p>
                             </div>
                         )}

--- a/packages/common/components/ui/tabs/tabs.tsx
+++ b/packages/common/components/ui/tabs/tabs.tsx
@@ -115,6 +115,7 @@ export function Tabs({
                             active={isActive}
                             disabled={isDisabled}
                             icon={tab.icon}
+                            label={tab.label}
                             route={tab.route}
                             tip={tab.tip}
                             variant="menu"

--- a/packages/pyrite/api/channels.ts
+++ b/packages/pyrite/api/channels.ts
@@ -46,10 +46,7 @@ export default async function apiChannels(router: Router) {
                 }
             }
 
-            return new Response(JSON.stringify({
-                channels: accessibleChannels,
-                success: true,
-            }), {
+            return new Response(JSON.stringify(accessibleChannels), {
                 headers: {'Content-Type': 'application/json'},
             })
         } catch (error) {
@@ -123,6 +120,321 @@ export default async function apiChannels(router: Router) {
             logger.error('[Channels API] Error getting channel:', error)
             return new Response(JSON.stringify({
                 error: error.message,
+                success: false,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+                status: 500,
+            })
+        }
+    })
+
+    /**
+     * Create a new channel
+     * POST /api/channels
+     */
+    router.post('/api/channels', async (req, params, session) => {
+        try {
+            // Get user ID from session (session.userid contains username)
+            let userId: string | null = null
+            if (session?.userid) {
+                const user = await userManager.getUserByUsername(session.userid)
+                if (user) {
+                    userId = user.id
+                }
+            }
+
+            if (!userId) {
+                return new Response(JSON.stringify({
+                    error: 'Unauthorized',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 401,
+                })
+            }
+
+            const body = await req.json()
+            const {name, slug, description} = body
+
+            if (!name || !slug) {
+                return new Response(JSON.stringify({
+                    error: 'Name and slug are required',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 400,
+                })
+            }
+
+            // Check if channel with same slug already exists
+            const existingChannel = channelManager!.getChannelBySlug(slug)
+            if (existingChannel) {
+                return new Response(JSON.stringify({
+                    error: 'Channel with this slug already exists',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 409,
+                })
+            }
+
+            // Create channel
+            const channel = await channelManager!.createChannel(
+                name,
+                slug,
+                description || '',
+                userId,
+            )
+
+            // Sync to Galene group
+            await channelManager!.syncChannelToGalene(channel)
+
+            return new Response(JSON.stringify(channel), {
+                headers: {'Content-Type': 'application/json'},
+            })
+        } catch (error) {
+            logger.error('[Channels API] Error creating channel:', error)
+            return new Response(JSON.stringify({
+                error: error instanceof Error ? error.message : 'Failed to create channel',
+                success: false,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+                status: 500,
+            })
+        }
+    })
+
+    /**
+     * Update a channel
+     * PUT /api/channels/:channelId
+     */
+    router.put('/api/channels/:channelId', async (req, params, session) => {
+        try {
+            const channelId = parseInt(params.param0, 10)
+
+            if (isNaN(channelId)) {
+                return new Response(JSON.stringify({
+                    error: 'Invalid channel ID',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 400,
+                })
+            }
+
+            // Get user ID from session
+            let userId: string | null = null
+            if (session?.userid) {
+                const user = await userManager.getUserByUsername(session.userid)
+                if (user) {
+                    userId = user.id
+                }
+            }
+
+            if (!userId) {
+                return new Response(JSON.stringify({
+                    error: 'Unauthorized',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 401,
+                })
+            }
+
+            // Check if user is admin of the channel
+            const userRole = channelManager!.getUserRole(channelId, userId)
+            if (userRole !== 'admin') {
+                return new Response(JSON.stringify({
+                    error: 'Access denied - admin role required',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 403,
+                })
+            }
+
+            const body = await req.json()
+            const updates: {name?: string; slug?: string; description?: string} = {}
+
+            if (body.name !== undefined) updates.name = body.name
+            if (body.slug !== undefined) updates.slug = body.slug
+            if (body.description !== undefined) updates.description = body.description
+
+            // If slug is being changed, check if new slug already exists
+            if (updates.slug) {
+                const existingChannel = channelManager!.getChannelBySlug(updates.slug)
+                if (existingChannel && existingChannel.id !== channelId) {
+                    return new Response(JSON.stringify({
+                        error: 'Channel with this slug already exists',
+                        success: false,
+                    }), {
+                        headers: {'Content-Type': 'application/json'},
+                        status: 409,
+                    })
+                }
+            }
+
+            const updatedChannel = await channelManager!.updateChannel(channelId, updates)
+
+            if (!updatedChannel) {
+                return new Response(JSON.stringify({
+                    error: 'Channel not found',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 404,
+                })
+            }
+
+            // Sync to Galene group
+            await channelManager!.syncChannelToGalene(updatedChannel)
+
+            return new Response(JSON.stringify(updatedChannel), {
+                headers: {'Content-Type': 'application/json'},
+            })
+        } catch (error) {
+            logger.error('[Channels API] Error updating channel:', error)
+            return new Response(JSON.stringify({
+                error: error instanceof Error ? error.message : 'Failed to update channel',
+                success: false,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+                status: 500,
+            })
+        }
+    })
+
+    /**
+     * Delete a channel
+     * DELETE /api/channels/:channelId
+     */
+    router.delete('/api/channels/:channelId', async (req, params, session) => {
+        try {
+            const channelId = parseInt(params.param0, 10)
+
+            if (isNaN(channelId)) {
+                return new Response(JSON.stringify({
+                    error: 'Invalid channel ID',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 400,
+                })
+            }
+
+            // Get user ID from session
+            let userId: string | null = null
+            if (session?.userid) {
+                const user = await userManager.getUserByUsername(session.userid)
+                if (user) {
+                    userId = user.id
+                }
+            }
+
+            if (!userId) {
+                return new Response(JSON.stringify({
+                    error: 'Unauthorized',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 401,
+                })
+            }
+
+            // Check if user is admin of the channel
+            const userRole = channelManager!.getUserRole(channelId, userId)
+            if (userRole !== 'admin') {
+                return new Response(JSON.stringify({
+                    error: 'Access denied - admin role required',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 403,
+                })
+            }
+
+            const channel = channelManager!.getChannel(channelId)
+            if (!channel) {
+                return new Response(JSON.stringify({
+                    error: 'Channel not found',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 404,
+                })
+            }
+
+            // Delete Galene group file first
+            await channelManager!.deleteGaleneGroup(channel.slug)
+
+            // Delete channel from database
+            const deleted = await channelManager!.deleteChannel(channelId)
+
+            if (!deleted) {
+                return new Response(JSON.stringify({
+                    error: 'Failed to delete channel',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 500,
+                })
+            }
+
+            return new Response(JSON.stringify({
+                success: true,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+            })
+        } catch (error) {
+            logger.error('[Channels API] Error deleting channel:', error)
+            return new Response(JSON.stringify({
+                error: error instanceof Error ? error.message : 'Failed to delete channel',
+                success: false,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+                status: 500,
+            })
+        }
+    })
+
+    /**
+     * Sync all channels to Galene groups
+     * POST /api/channels/sync
+     */
+    router.post('/api/channels/sync', async (req, params, session) => {
+        try {
+            // Get user ID from session
+            let userId: string | null = null
+            if (session?.userid) {
+                const user = await userManager.getUserByUsername(session.userid)
+                if (user) {
+                    userId = user.id
+                }
+            }
+
+            if (!userId) {
+                return new Response(JSON.stringify({
+                    error: 'Unauthorized',
+                    success: false,
+                }), {
+                    headers: {'Content-Type': 'application/json'},
+                    status: 401,
+                })
+            }
+
+            // Sync all channels to Galene
+            const result = await channelManager!.syncAllChannelsToGalene()
+
+            return new Response(JSON.stringify({
+                failed: result.failed,
+                success: result.success,
+            }), {
+                headers: {'Content-Type': 'application/json'},
+            })
+        } catch (error) {
+            logger.error('[Channels API] Error syncing channels:', error)
+            return new Response(JSON.stringify({
+                error: error instanceof Error ? error.message : 'Failed to sync channels',
                 success: false,
             }), {
                 headers: {'Content-Type': 'application/json'},

--- a/packages/pyrite/src/components/settings/settings.tsx
+++ b/packages/pyrite/src/components/settings/settings.tsx
@@ -48,7 +48,7 @@ export default function Settings({tabId}: SettingsProps) {
     const tabs = [
         {
             component: <Profile />,
-            icon: 'Settings',
+            icon: 'settings',
             id: 'profile',
             label: $t('ui.settings.profile.name'),
             tip: $t('ui.settings.profile.name'),
@@ -56,7 +56,7 @@ export default function Settings({tabId}: SettingsProps) {
         ...(showUserSettings ? [
             {
                 component: <UsersManagement $t={$t} />,
-                icon: 'account',
+                icon: 'user',
                 id: 'users',
                 label: $t('ui.settings.users.name'),
                 tip: $t('ui.settings.users.name'),
@@ -71,14 +71,14 @@ export default function Settings({tabId}: SettingsProps) {
         },
         {
             component: <TabDevices />,
-            icon: 'Webcam',
+            icon: 'webcam',
             id: 'devices',
             label: $t('ui.settings.devices'),
             tip: $t('ui.settings.devices'),
         },
         {
             component: <TabMedia />,
-            icon: 'Media',
+            icon: 'media',
             id: 'media',
             label: $t('ui.settings.media.name'),
             tip: $t('ui.settings.media.name'),
@@ -93,7 +93,7 @@ export default function Settings({tabId}: SettingsProps) {
             activeTabId={activeTabId}
             defaultTab="profile"
             getRoute={getRoute}
-            onSave={saveSettings}
+            showSave={false}
         />
     )
 }

--- a/packages/pyrite/src/components/settings/settings.tsx
+++ b/packages/pyrite/src/components/settings/settings.tsx
@@ -50,16 +50,16 @@ export default function Settings({tabId}: SettingsProps) {
             component: <Profile />,
             icon: 'settings',
             id: 'profile',
-            label: $t('ui.settings.profile.name'),
-            tip: $t('ui.settings.profile.name'),
+            label: $t('ui.settings.profile.name') || 'Profile',
+            tip: $t('ui.settings.profile.name') || 'Profile',
         },
         ...(showUserSettings ? [
             {
                 component: <UsersManagement $t={$t} />,
                 icon: 'user',
                 id: 'users',
-                label: $t('ui.settings.users.name'),
-                tip: $t('ui.settings.users.name'),
+                label: $t('ui.settings.users.name') || 'Users',
+                tip: $t('ui.settings.users.name') || 'Users',
             },
         ] : []),
         {
@@ -73,15 +73,15 @@ export default function Settings({tabId}: SettingsProps) {
             component: <TabDevices />,
             icon: 'webcam',
             id: 'devices',
-            label: $t('ui.settings.devices'),
-            tip: $t('ui.settings.devices'),
+            label: $t('ui.settings.devices') || 'Devices',
+            tip: $t('ui.settings.devices') || 'Devices',
         },
         {
             component: <TabMedia />,
             icon: 'media',
             id: 'media',
-            label: $t('ui.settings.media.name'),
-            tip: $t('ui.settings.media.name'),
+            label: $t('ui.settings.media.name') || 'Media',
+            tip: $t('ui.settings.media.name') || 'Media',
         },
     ]
 

--- a/packages/pyrite/src/components/settings/settings.tsx
+++ b/packages/pyrite/src/components/settings/settings.tsx
@@ -64,10 +64,10 @@ export default function Settings({tabId}: SettingsProps) {
         ] : []),
         {
             component: <TabChannels />,
-            icon: 'Channel',
+            icon: 'chat',
             id: 'channels',
-            label: $t('ui.settings.channels.name'),
-            tip: $t('ui.settings.channels.name'),
+            label: $t('ui.settings.channels.name') || 'Channels',
+            tip: $t('ui.settings.channels.name') || 'Channels',
         },
         {
             component: <TabDevices />,

--- a/packages/pyrite/src/components/settings/tabs/channels.css
+++ b/packages/pyrite/src/components/settings/tabs/channels.css
@@ -59,3 +59,34 @@
     display: flex;
     gap: var(--spacer-1);
 }
+
+.c-settings-tab-channels__header-actions {
+    display: flex;
+    gap: var(--spacer-2);
+}
+
+.c-settings-tab-channels__create-form {
+    background: var(--surface-2);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--spacer-1);
+    padding: var(--spacer-3);
+
+    h3 {
+        color: var(--surface-7);
+        font-size: var(--font-d);
+        font-weight: var(--font-weight-semibold, 600);
+        margin: 0 0 var(--spacer-2);
+    }
+}
+
+.c-settings-tab-channels__slug {
+    color: var(--surface-5);
+    font-family: monospace;
+    font-size: var(--font-s);
+}
+
+.c-settings-tab-channels__empty {
+    color: var(--surface-6);
+    padding: var(--spacer-4);
+    text-align: center;
+}

--- a/packages/pyrite/src/components/settings/tabs/channels.css
+++ b/packages/pyrite/src/components/settings/tabs/channels.css
@@ -2,91 +2,86 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacer-4);
-}
 
-.c-settings-tab-channels__header {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
+    .header {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
 
-    h2 {
-        color: var(--surface-7);
-        font-size: var(--font-l);
-        font-weight: var(--font-weight-semibold, 600);
-        margin: 0;
-    }
-}
-
-.c-settings-tab-channels__list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
-}
-
-.c-settings-tab-channels__item {
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--spacer-1);
-    padding: var(--spacer-2);
-}
-
-.c-settings-tab-channels__form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacer-2);
-}
-
-.c-settings-tab-channels__content {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
-
-    h3 {
-        color: var(--surface-8);
-        font-size: var(--font-d);
-        font-weight: var(--font-weight-semibold, 600);
-        margin: 0 0 var(--spacer-1);
+        h2 {
+            color: var(--surface-7);
+            font-size: var(--font-l);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0;
+        }
     }
 
-    p {
+    .list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacer-2);
+    }
+
+    .item {
+        background: var(--surface-2);
+        border: 1px solid var(--surface-3);
+        border-radius: var(--spacer-1);
+        padding: var(--spacer-2);
+    }
+
+    .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacer-2);
+    }
+
+    .content {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
+
+        h3 {
+            color: var(--surface-8);
+            font-size: var(--font-d);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0 0 var(--spacer-1);
+        }
+
+        p {
+            color: var(--surface-6);
+            font-size: var(--font-s);
+            margin: 0;
+        }
+
+        .slug {
+            color: var(--surface-5);
+            font-family: monospace;
+            font-size: var(--font-s);
+        }
+    }
+
+    .actions {
+        display: flex;
+        gap: var(--spacer-1);
+    }
+
+    .create-form {
+        background: var(--surface-2);
+        border: 1px solid var(--surface-3);
+        border-radius: var(--spacer-1);
+        padding: var(--spacer-3);
+
+        h3 {
+            color: var(--surface-7);
+            font-size: var(--font-d);
+            font-weight: var(--font-weight-semibold, 600);
+            margin: 0 0 var(--spacer-2);
+        }
+    }
+
+    .empty {
         color: var(--surface-6);
-        font-size: var(--font-s);
-        margin: 0;
+        padding: var(--spacer-4);
+        text-align: center;
     }
-}
-
-.c-settings-tab-channels__actions {
-    display: flex;
-    gap: var(--spacer-1);
-}
-
-.c-settings-tab-channels__header-actions {
-    display: flex;
-    gap: var(--spacer-2);
-}
-
-.c-settings-tab-channels__create-form {
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--spacer-1);
-    padding: var(--spacer-3);
-
-    h3 {
-        color: var(--surface-7);
-        font-size: var(--font-d);
-        font-weight: var(--font-weight-semibold, 600);
-        margin: 0 0 var(--spacer-2);
-    }
-}
-
-.c-settings-tab-channels__slug {
-    color: var(--surface-5);
-    font-family: monospace;
-    font-size: var(--font-s);
-}
-
-.c-settings-tab-channels__empty {
-    color: var(--surface-6);
-    padding: var(--spacer-4);
-    text-align: center;
 }

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -1,26 +1,33 @@
 import {FieldText, Button} from '@garage44/common/components'
-import {useEffect, useState} from 'preact/hooks'
+import {useEffect, useRef} from 'preact/hooks'
+import {deepSignal} from 'deepsignal'
 import {api, notifier} from '@garage44/common/app'
 import type {Channel} from '@/types'
 
 export default function TabChannels() {
-    const [channels, setChannels] = useState<Channel[]>([])
-    const [loading, setLoading] = useState(false)
-    const [editing, setEditing] = useState<number | null>(null)
-    const [formData, setFormData] = useState<{description: string; name: string}>({
-        description: '',
-        name: '',
-    })
+    // Use DeepSignal for component state (per-instance, stable across renders)
+    const stateRef = useRef(deepSignal({
+        channels: [] as Channel[],
+        loading: false,
+        syncing: false,
+        editing: null as number | null,
+        formData: {
+            description: '',
+            name: '',
+            slug: '',
+        },
+    }))
+    const state = stateRef.current
 
     const loadChannels = async () => {
-        setLoading(true)
+        state.loading = true
         try {
             const data = await api.get('/api/channels')
-            setChannels(Array.isArray(data) ? data : [])
+            state.channels = Array.isArray(data) ? data : []
         } catch {
             notifier.notify({level: 'error', message: 'Failed to load channels'})
         } finally {
-            setLoading(false)
+            state.loading = false
         }
     }
 
@@ -29,124 +36,212 @@ export default function TabChannels() {
     }, [])
 
     const handleCreate = async () => {
+        if (!state.formData.name || !state.formData.slug) {
+            notifier.notify({level: 'error', message: 'Name and slug are required'})
+            return
+        }
+
         try {
-            const newChannel = await api.post('/api/channels', formData)
-            setChannels([...channels, newChannel])
-            setFormData({description: '', name: ''})
-            notifier.notify({level: 'success', message: 'Channel created'})
-        } catch {
-            notifier.notify({level: 'error', message: 'Failed to create channel'})
+            const newChannel = await api.post('/api/channels', {
+                name: state.formData.name,
+                slug: state.formData.slug,
+                description: state.formData.description,
+            })
+            state.channels = [...state.channels, newChannel]
+            state.formData = {description: '', name: '', slug: ''}
+            notifier.notify({level: 'success', message: 'Channel created and synced with Galene'})
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to create channel'
+            notifier.notify({level: 'error', message})
         }
     }
 
     const handleUpdate = async (channelId: number) => {
         try {
-            const updated = await api.put(`/api/channels/${channelId}`, formData)
-            setChannels(channels.map((c) => c.id === channelId ? updated : c))
-            setEditing(null)
-            setFormData({description: '', name: ''})
-            notifier.notify({level: 'success', message: 'Channel updated'})
-        } catch {
-            notifier.notify({level: 'error', message: 'Failed to update channel'})
+            const updated = await api.put(`/api/channels/${channelId}`, {
+                name: state.formData.name,
+                slug: state.formData.slug,
+                description: state.formData.description,
+            })
+            state.channels = state.channels.map((c) => c.id === channelId ? updated : c)
+            state.editing = null
+            state.formData = {description: '', name: '', slug: ''}
+            notifier.notify({level: 'success', message: 'Channel updated and synced with Galene'})
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to update channel'
+            notifier.notify({level: 'error', message})
         }
     }
 
     const handleDelete = async (channelId: number) => {
-        if (!confirm('Are you sure you want to delete this channel?')) return
+        if (!confirm('Are you sure you want to delete this channel? This will also delete the associated Galene group.')) return
 
         try {
             await api.delete(`/api/channels/${channelId}`)
-            setChannels(channels.filter((c) => c.id !== channelId))
-            notifier.notify({level: 'success', message: 'Channel deleted'})
-        } catch {
-            notifier.notify({level: 'error', message: 'Failed to delete channel'})
+            state.channels = state.channels.filter((c) => c.id !== channelId)
+            notifier.notify({level: 'success', message: 'Channel deleted and Galene group removed'})
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to delete channel'
+            notifier.notify({level: 'error', message})
+        }
+    }
+
+    const handleSyncAll = async () => {
+        state.syncing = true
+        try {
+            // Sync all channels by calling sync endpoint
+            const response = await api.post('/api/channels/sync', {})
+            const {success, failed} = response
+            if (failed > 0) {
+                notifier.notify({level: 'warning', message: `Synced ${success} channels, ${failed} failed`})
+            } else {
+                notifier.notify({level: 'success', message: `Successfully synced ${success} channels with Galene`})
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to sync channels'
+            notifier.notify({level: 'error', message})
+        } finally {
+            state.syncing = false
         }
     }
 
     const startEdit = (channel: Channel) => {
-        setEditing(channel.id)
-        setFormData({
+        state.editing = channel.id
+        state.formData = {
             description: channel.description || '',
             name: channel.name,
-        })
+            slug: channel.slug,
+        }
     }
 
     const cancelEdit = () => {
-        setEditing(null)
-        setFormData({description: '', name: ''})
+        state.editing = null
+        state.formData = {description: '', name: '', slug: ''}
     }
 
     return (
         <section class="c-settings-tab-channels tab-content active">
             <div class="c-settings-tab-channels__header">
                 <h2>Channel Configuration</h2>
-                <Button
-                    icon="Plus"
-                    label="Create Channel"
-                    onClick={handleCreate}
-                    type="info"
-                />
+                <div class="c-settings-tab-channels__header-actions">
+                    <Button
+                        icon="Sync"
+                        label="Sync All with Galene"
+                        onClick={handleSyncAll}
+                        type="info"
+                        disabled={state.syncing}
+                    />
+                    <Button
+                        icon="Plus"
+                        label="Create Channel"
+                        onClick={handleCreate}
+                        type="info"
+                    />
+                </div>
             </div>
 
-            {loading ? (
+            {state.loading ? (
                 <div>Loading channels...</div>
             ) : (
-                <div class="c-settings-tab-channels__list">
-                    {channels.map((channel) => (
-                        <div key={channel.id} class="c-settings-tab-channels__item">
-                            {editing === channel.id ? (
-                                <div class="c-settings-tab-channels__form">
-                                    <FieldText
-                                        value={formData.name}
-                                        onChange={(value) => setFormData({...formData, name: value})}
-                                        label="Channel Name"
+                <>
+                    {state.editing === null && (
+                        <div class="c-settings-tab-channels__create-form">
+                            <h3>Create New Channel</h3>
+                            <div class="c-settings-tab-channels__form">
+                                <FieldText
+                                    model={state.$formData.name}
+                                    label="Channel Name"
+                                    placeholder="Enter channel name"
+                                />
+                                <FieldText
+                                    model={state.$formData.slug}
+                                    label="Slug (Galene Group Name)"
+                                    placeholder="Enter slug (must match Galene group name)"
+                                    help="This slug will be used as the Galene group name"
+                                />
+                                <FieldText
+                                    model={state.$formData.description}
+                                    label="Description"
+                                    placeholder="Enter channel description"
+                                />
+                                <div class="c-settings-tab-channels__actions">
+                                    <Button
+                                        icon="Plus"
+                                        label="Create Channel"
+                                        onClick={handleCreate}
+                                        type="success"
                                     />
-                                    <FieldText
-                                        value={formData.description}
-                                        onChange={(value) => setFormData({...formData, description: value})}
-                                        label="Description"
-                                    />
-                                    <div class="c-settings-tab-channels__actions">
-                                        <Button
-                                            icon="Save"
-                                            label="Save"
-                                            onClick={() => handleUpdate(channel.id)}
-                                            type="success"
-                                        />
-                                        <Button
-                                            icon="Close"
-                                            label="Cancel"
-                                            onClick={cancelEdit}
-                                            type="default"
-                                        />
-                                    </div>
                                 </div>
-                            ) : (
-                                <div class="c-settings-tab-channels__content">
-                                    <div>
-                                        <h3>{channel.name}</h3>
-                                        <p>{channel.description || 'No description'}</p>
-                                    </div>
-                                    <div class="c-settings-tab-channels__actions">
-                                        <Button
-                                            icon="Edit"
-                                            onClick={() => startEdit(channel)}
-                                            tip="Edit"
-                                            variant="menu"
-                                        />
-                                        <Button
-                                            icon="Trash"
-                                            onClick={() => handleDelete(channel.id)}
-                                            tip="Delete"
-                                            type="danger"
-                                            variant="menu"
-                                        />
-                                    </div>
-                                </div>
-                            )}
+                            </div>
                         </div>
-                    ))}
-                </div>
+                    )}
+
+                    <div class="c-settings-tab-channels__list">
+                        {state.channels.map((channel) => (
+                            <div key={channel.id} class="c-settings-tab-channels__item">
+                                {state.editing === channel.id ? (
+                                    <div class="c-settings-tab-channels__form">
+                                        <FieldText
+                                            model={state.$formData.name}
+                                            label="Channel Name"
+                                        />
+                                        <FieldText
+                                            model={state.$formData.slug}
+                                            label="Slug (Galene Group Name)"
+                                            help="This slug will be used as the Galene group name"
+                                        />
+                                        <FieldText
+                                            model={state.$formData.description}
+                                            label="Description"
+                                        />
+                                        <div class="c-settings-tab-channels__actions">
+                                            <Button
+                                                icon="Save"
+                                                label="Save"
+                                                onClick={() => handleUpdate(channel.id)}
+                                                type="success"
+                                            />
+                                            <Button
+                                                icon="Close"
+                                                label="Cancel"
+                                                onClick={cancelEdit}
+                                                type="default"
+                                            />
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div class="c-settings-tab-channels__content">
+                                        <div>
+                                            <h3>{channel.name}</h3>
+                                            <p class="c-settings-tab-channels__slug">Slug: {channel.slug}</p>
+                                            <p>{channel.description || 'No description'}</p>
+                                        </div>
+                                        <div class="c-settings-tab-channels__actions">
+                                            <Button
+                                                icon="Edit"
+                                                onClick={() => startEdit(channel)}
+                                                tip="Edit"
+                                                variant="menu"
+                                            />
+                                            <Button
+                                                icon="Trash"
+                                                onClick={() => handleDelete(channel.id)}
+                                                tip="Delete"
+                                                type="danger"
+                                                variant="menu"
+                                            />
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                        {state.channels.length === 0 && (
+                            <div class="c-settings-tab-channels__empty">
+                                <p>No channels yet. Create your first channel above.</p>
+                            </div>
+                        )}
+                    </div>
+                </>
             )}
         </section>
     )

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -9,7 +9,6 @@ export default function TabChannels() {
     const stateRef = useRef(deepSignal({
         channels: [] as Channel[],
         loading: false,
-        syncing: false,
         editing: null as number | null,
         formData: {
             description: '',
@@ -86,24 +85,6 @@ export default function TabChannels() {
         }
     }
 
-    const handleSyncAll = async () => {
-        state.syncing = true
-        try {
-            // Sync all channels by calling sync endpoint
-            const response = await api.post('/api/channels/sync', {})
-            const {success, failed} = response
-            if (failed > 0) {
-                notifier.notify({level: 'warning', message: `Synced ${success} channels, ${failed} failed`})
-            } else {
-                notifier.notify({level: 'success', message: `Successfully synced ${success} channels with Galene`})
-            }
-        } catch (error) {
-            const message = error instanceof Error ? error.message : 'Failed to sync channels'
-            notifier.notify({level: 'error', message})
-        } finally {
-            state.syncing = false
-        }
-    }
 
     const startEdit = (channel: Channel) => {
         state.editing = channel.id
@@ -123,21 +104,6 @@ export default function TabChannels() {
         <section class="c-settings-tab-channels tab-content active">
             <div class="c-settings-tab-channels__header">
                 <h2>Channel Configuration</h2>
-                <div class="c-settings-tab-channels__header-actions">
-                    <Button
-                        icon="Sync"
-                        label="Sync All with Galene"
-                        onClick={handleSyncAll}
-                        type="info"
-                        disabled={state.syncing}
-                    />
-                    <Button
-                        icon="Plus"
-                        label="Create Channel"
-                        onClick={handleCreate}
-                        type="info"
-                    />
-                </div>
             </div>
 
             {state.loading ? (
@@ -149,24 +115,27 @@ export default function TabChannels() {
                             <h3>Create New Channel</h3>
                             <div class="c-settings-tab-channels__form">
                                 <FieldText
-                                    model={state.$formData.name}
+                                    value={state.formData.name}
+                                    onChange={(value) => state.formData.name = value}
                                     label="Channel Name"
                                     placeholder="Enter channel name"
                                 />
                                 <FieldText
-                                    model={state.$formData.slug}
+                                    value={state.formData.slug}
+                                    onChange={(value) => state.formData.slug = value}
                                     label="Slug (Galene Group Name)"
                                     placeholder="Enter slug (must match Galene group name)"
                                     help="This slug will be used as the Galene group name"
                                 />
                                 <FieldText
-                                    model={state.$formData.description}
+                                    value={state.formData.description}
+                                    onChange={(value) => state.formData.description = value}
                                     label="Description"
                                     placeholder="Enter channel description"
                                 />
                                 <div class="c-settings-tab-channels__actions">
                                     <Button
-                                        icon="Plus"
+                                        icon="plus"
                                         label="Create Channel"
                                         onClick={handleCreate}
                                         type="success"
@@ -182,27 +151,30 @@ export default function TabChannels() {
                                 {state.editing === channel.id ? (
                                     <div class="c-settings-tab-channels__form">
                                         <FieldText
-                                            model={state.$formData.name}
+                                            value={state.formData.name}
+                                            onChange={(value) => state.formData.name = value}
                                             label="Channel Name"
                                         />
                                         <FieldText
-                                            model={state.$formData.slug}
+                                            value={state.formData.slug}
+                                            onChange={(value) => state.formData.slug = value}
                                             label="Slug (Galene Group Name)"
                                             help="This slug will be used as the Galene group name"
                                         />
                                         <FieldText
-                                            model={state.$formData.description}
+                                            value={state.formData.description}
+                                            onChange={(value) => state.formData.description = value}
                                             label="Description"
                                         />
                                         <div class="c-settings-tab-channels__actions">
                                             <Button
-                                                icon="Save"
+                                                icon="save"
                                                 label="Save"
                                                 onClick={() => handleUpdate(channel.id)}
                                                 type="success"
                                             />
                                             <Button
-                                                icon="Close"
+                                                icon="close"
                                                 label="Cancel"
                                                 onClick={cancelEdit}
                                                 type="default"
@@ -218,13 +190,13 @@ export default function TabChannels() {
                                         </div>
                                         <div class="c-settings-tab-channels__actions">
                                             <Button
-                                                icon="Edit"
+                                                icon="edit"
                                                 onClick={() => startEdit(channel)}
                                                 tip="Edit"
                                                 variant="menu"
                                             />
                                             <Button
-                                                icon="Trash"
+                                                icon="trash"
                                                 onClick={() => handleDelete(channel.id)}
                                                 tip="Delete"
                                                 type="danger"

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -115,18 +115,18 @@ export default function TabChannels() {
                             <h3>Create New Channel</h3>
                             <div class="c-settings-tab-channels__form">
                                 <FieldText
-                                    model={state.$formData.name}
+                                    model={state.formData.$name}
                                     label="Channel Name"
                                     placeholder="Enter channel name"
                                 />
                                 <FieldText
-                                    model={state.$formData.slug}
+                                    model={state.formData.$slug}
                                     label="Slug (Galene Group Name)"
                                     placeholder="Enter slug (must match Galene group name)"
                                     help="This slug will be used as the Galene group name"
                                 />
                                 <FieldText
-                                    model={state.$formData.description}
+                                    model={state.formData.$description}
                                     label="Description"
                                     placeholder="Enter channel description"
                                 />
@@ -148,16 +148,16 @@ export default function TabChannels() {
                                 {state.editing === channel.id ? (
                                     <div class="c-settings-tab-channels__form">
                                         <FieldText
-                                            model={state.$formData.name}
+                                            model={state.formData.$name}
                                             label="Channel Name"
                                         />
                                         <FieldText
-                                            model={state.$formData.slug}
+                                            model={state.formData.$slug}
                                             label="Slug (Galene Group Name)"
                                             help="This slug will be used as the Galene group name"
                                         />
                                         <FieldText
-                                            model={state.$formData.description}
+                                            model={state.formData.$description}
                                             label="Description"
                                         />
                                         <div class="c-settings-tab-channels__actions">

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -102,7 +102,7 @@ export default function TabChannels() {
 
     return (
         <section class="c-settings-tab-channels">
-            <div class="c-settings-tab-channels__header">
+            <div class="header">
                 <h2>Channel Configuration</h2>
             </div>
 
@@ -111,9 +111,9 @@ export default function TabChannels() {
             ) : (
                 <>
                     {state.editing === null && (
-                        <div class="c-settings-tab-channels__create-form">
+                        <div class="create-form">
                             <h3>Create New Channel</h3>
-                            <div class="c-settings-tab-channels__form">
+                            <div class="form">
                                 <FieldText
                                     model={state.formData.$name}
                                     label="Channel Name"
@@ -130,7 +130,7 @@ export default function TabChannels() {
                                     label="Description"
                                     placeholder="Enter channel description"
                                 />
-                                <div class="c-settings-tab-channels__actions">
+                                <div class="actions">
                                     <Button
                                         icon="plus"
                                         label="Create Channel"
@@ -142,11 +142,11 @@ export default function TabChannels() {
                         </div>
                     )}
 
-                    <div class="c-settings-tab-channels__list">
+                    <div class="list">
                         {state.channels.map((channel) => (
-                            <div key={channel.id} class="c-settings-tab-channels__item">
+                            <div key={channel.id} class="item">
                                 {state.editing === channel.id ? (
-                                    <div class="c-settings-tab-channels__form">
+                                    <div class="form">
                                         <FieldText
                                             model={state.formData.$name}
                                             label="Channel Name"
@@ -160,7 +160,7 @@ export default function TabChannels() {
                                             model={state.formData.$description}
                                             label="Description"
                                         />
-                                        <div class="c-settings-tab-channels__actions">
+                                        <div class="actions">
                                             <Button
                                                 icon="save"
                                                 label="Save"
@@ -176,13 +176,13 @@ export default function TabChannels() {
                                         </div>
                                     </div>
                                 ) : (
-                                    <div class="c-settings-tab-channels__content">
+                                    <div class="content">
                                         <div>
                                             <h3>{channel.name}</h3>
-                                            <p class="c-settings-tab-channels__slug">Slug: {channel.slug}</p>
+                                            <p class="slug">Slug: {channel.slug}</p>
                                             <p>{channel.description || 'No description'}</p>
                                         </div>
-                                        <div class="c-settings-tab-channels__actions">
+                                        <div class="actions">
                                             <Button
                                                 icon="edit"
                                                 onClick={() => startEdit(channel)}
@@ -202,7 +202,7 @@ export default function TabChannels() {
                             </div>
                         ))}
                         {state.channels.length === 0 && (
-                            <div class="c-settings-tab-channels__empty">
+                            <div class="empty">
                                 <p>No channels yet. Create your first channel above.</p>
                             </div>
                         )}

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -101,7 +101,7 @@ export default function TabChannels() {
     }
 
     return (
-        <section class="c-settings-tab-channels tab-content active">
+        <section class="c-settings-tab-channels">
             <div class="c-settings-tab-channels__header">
                 <h2>Channel Configuration</h2>
             </div>
@@ -115,21 +115,18 @@ export default function TabChannels() {
                             <h3>Create New Channel</h3>
                             <div class="c-settings-tab-channels__form">
                                 <FieldText
-                                    value={state.formData.name}
-                                    onChange={(value) => state.formData.name = value}
+                                    model={state.$formData.name}
                                     label="Channel Name"
                                     placeholder="Enter channel name"
                                 />
                                 <FieldText
-                                    value={state.formData.slug}
-                                    onChange={(value) => state.formData.slug = value}
+                                    model={state.$formData.slug}
                                     label="Slug (Galene Group Name)"
                                     placeholder="Enter slug (must match Galene group name)"
                                     help="This slug will be used as the Galene group name"
                                 />
                                 <FieldText
-                                    value={state.formData.description}
-                                    onChange={(value) => state.formData.description = value}
+                                    model={state.$formData.description}
                                     label="Description"
                                     placeholder="Enter channel description"
                                 />
@@ -151,19 +148,16 @@ export default function TabChannels() {
                                 {state.editing === channel.id ? (
                                     <div class="c-settings-tab-channels__form">
                                         <FieldText
-                                            value={state.formData.name}
-                                            onChange={(value) => state.formData.name = value}
+                                            model={state.$formData.name}
                                             label="Channel Name"
                                         />
                                         <FieldText
-                                            value={state.formData.slug}
-                                            onChange={(value) => state.formData.slug = value}
+                                            model={state.$formData.slug}
                                             label="Slug (Galene Group Name)"
                                             help="This slug will be used as the Galene group name"
                                         />
                                         <FieldText
-                                            value={state.formData.description}
-                                            onChange={(value) => state.formData.description = value}
+                                            model={state.$formData.description}
                                             label="Description"
                                         />
                                         <div class="c-settings-tab-channels__actions">

--- a/packages/pyrite/src/components/settings/tabs/devices.tsx
+++ b/packages/pyrite/src/components/settings/tabs/devices.tsx
@@ -93,8 +93,7 @@ export default function TabDevices() {
         <section class="c-tab-devices">
             <div class="camera-field">
                 <FieldSelect
-                    value={$s.devices.cam.selected}
-                    onChange={(value) => $s.devices.cam.selected = value}
+                    model={$s.devices.cam.$selected}
                     help={$t('device.select_cam_help')}
                     label={$t('device.select_cam_label')}
                     name="video"
@@ -110,8 +109,7 @@ export default function TabDevices() {
             </div>
 
             <FieldSelect
-                value={$s.devices.mic.selected}
-                onChange={(value) => $s.devices.mic.selected = value}
+                model={$s.devices.mic.$selected}
                 help={$t('device.select_mic_verify_help')}
                 label={$t('device.select_mic_label')}
                 name="audio"
@@ -127,8 +125,7 @@ export default function TabDevices() {
                 {/* https://bugzilla.mozilla.org/show_bug.cgi?id=1152401 */}
                 {$s.devices.audio.options.length && !$s.env.isFirefox && (
                     <FieldSelect
-                        value={$s.devices.audio.selected}
-                        onChange={(value) => $s.devices.audio.selected = value}
+                        model={$s.devices.audio.$selected}
                         help={$t('device.select_audio_verify_help')}
                         label={$t('device.select_audio_label')}
                         name="audio"

--- a/packages/pyrite/src/components/settings/tabs/devices.tsx
+++ b/packages/pyrite/src/components/settings/tabs/devices.tsx
@@ -90,7 +90,7 @@ export default function TabDevices() {
     }, [$s.devices.cam.resolution, $s.devices.cam.selected, $s.devices.mic.selected])
 
     return (
-        <section class="c-tab-devices tab-content active">
+        <section class="c-tab-devices">
             <div class="camera-field">
                 <FieldSelect
                     value={$s.devices.cam.selected}

--- a/packages/pyrite/src/components/settings/tabs/media.tsx
+++ b/packages/pyrite/src/components/settings/tabs/media.tsx
@@ -32,7 +32,7 @@ export default function TabMedia() {
     ]
 
     return (
-        <section class="tab-content active">
+        <section class="c-tab-media">
             <FieldSelect
                 value={$s.media.accept}
                 onChange={(value) => $s.media.accept = value}

--- a/packages/pyrite/src/components/settings/tabs/media.tsx
+++ b/packages/pyrite/src/components/settings/tabs/media.tsx
@@ -34,8 +34,7 @@ export default function TabMedia() {
     return (
         <section class="c-tab-media">
             <FieldSelect
-                value={$s.media.accept}
-                onChange={(value) => $s.media.accept = value}
+                model={$s.media.$accept}
                 help={$t('ui.settings.media.accept_help')}
                 label={$t('ui.settings.media.accept_label')}
                 name="request"
@@ -43,8 +42,7 @@ export default function TabMedia() {
             />
 
             <FieldSelect
-                value={$s.devices.cam.resolution}
-                onChange={(value) => $s.devices.cam.resolution = value}
+                model={$s.devices.cam.$resolution}
                 help={$t('ui.settings.media.resolution_help')}
                 label={$t('ui.settings.media.resolution_label')}
                 name="resolution"
@@ -52,8 +50,7 @@ export default function TabMedia() {
             />
 
             <FieldSelect
-                value={$s.media.upstream}
-                onChange={(value) => $s.media.upstream = value}
+                model={$s.media.$upstream}
                 help={$t('ui.settings.media.bandwidth_help')}
                 label={$t('ui.settings.media.bandwidth_label')}
                 name="send"


### PR DESCRIPTION
Add a Settings tab for managing Pyrite channels with automatic Galene group synchronization.

Channels are now automatically synced with Galene groups on creation, update, and deletion, using a `slug` field for 1:1 mapping. A manual "Sync All" option is also available for bulk operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f5883c5-6a9b-49e1-afd1-1b05da46051e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f5883c5-6a9b-49e1-afd1-1b05da46051e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

