### PR TITLE
Adjust mobile panel context and menu toggle

### DIFF
--- a/packages/common/components/ui/app-layout/app-layout.css
+++ b/packages/common/components/ui/app-layout/app-layout.css
@@ -45,104 +45,8 @@
     }
 }
 
-/* Mobile menu toggle button */
-.c-mobile-menu-toggle {
-    position: fixed;
-    top: var(--spacer-1);
-    right: var(--spacer-1);
-    z-index: 1001;
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--border-radius-s);
-    color: var(--surface-7);
-    cursor: pointer;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    padding: var(--spacer-1);
-    width: var(--spacer-6);
-    height: var(--spacer-6);
-    min-width: var(--spacer-6);
-    min-height: var(--spacer-6);
-    transition: all 0.2s ease;
-    box-shadow: var(--shadow-d);
-
-    &:hover {
-        background: var(--surface-3);
-        color: var(--surface-8);
-    }
-
-    &:active {
-        transform: scale(0.95);
-    }
-
-    svg {
-        display: block;
-        width: 20px;
-        height: 20px;
-        flex-shrink: 0;
-    }
-
-    /* Show button on mobile when visible */
-    @media (max-width: 768px) {
-        &.is-visible {
-            display: flex !important;
-            visibility: visible !important;
-            opacity: 1 !important;
-        }
-    }
-}
-
-/* Mobile menu close button */
-.c-mobile-menu-close {
-    position: fixed;
-    top: var(--spacer-1);
-    right: var(--spacer-1);
-    z-index: 1002;
-    background: var(--surface-2);
-    border: 1px solid var(--surface-3);
-    border-radius: var(--border-radius-s);
-    color: var(--surface-7);
-    cursor: pointer;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    padding: var(--spacer-1);
-    width: var(--spacer-6);
-    height: var(--spacer-6);
-    min-width: var(--spacer-6);
-    min-height: var(--spacer-6);
-    transition: all 0.2s ease;
-    box-shadow: var(--shadow-d);
-
-    &:hover {
-        background: var(--surface-3);
-        color: var(--surface-8);
-    }
-
-    &:active {
-        transform: scale(0.95);
-    }
-
-    svg {
-        display: block;
-        width: 20px;
-        height: 20px;
-        flex-shrink: 0;
-    }
-
-    /* Show button on mobile when visible */
-    @media (max-width: 768px) {
-        &.is-visible {
-            display: flex !important;
-            visibility: visible !important;
-            opacity: 1 !important;
-        }
-    }
-}
-
-/* Mobile context toggle button - positioned top-left */
-.c-mobile-context-toggle {
+/* Unified mobile panel toggle button - positioned top-left */
+.c-mobile-panel-toggle {
     position: fixed;
     top: var(--spacer-1);
     left: var(--spacer-1);
@@ -179,18 +83,14 @@
         flex-shrink: 0;
     }
 
-    /* Show button on mobile when visible */
+    /* Show button on mobile */
     @media (max-width: 768px) {
-        &.is-visible {
-            display: flex !important;
-            visibility: visible !important;
-            opacity: 1 !important;
-        }
+        display: flex;
     }
 }
 
-/* Mobile context close button - positioned top-left */
-.c-mobile-context-close {
+/* Unified mobile panel close button - positioned top-left */
+.c-mobile-panel-close {
     position: fixed;
     top: var(--spacer-1);
     left: var(--spacer-1);
@@ -227,30 +127,60 @@
         flex-shrink: 0;
     }
 
-    /* Show button on mobile when visible */
+    /* Show button on mobile when panel is open */
     @media (max-width: 768px) {
-        &.is-visible {
-            display: flex !important;
-            visibility: visible !important;
-            opacity: 1 !important;
-        }
+        display: flex;
     }
 }
 
-/* Mobile backdrop overlays */
-.c-panel-menu-backdrop {
+/* Panel switcher tabs - shown when both panels exist */
+.c-panel-switcher {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(2px);
-    z-index: 999;
-    animation: fade-in 0.3s ease-in-out;
+    top: var(--spacer-1);
+    left: calc(var(--spacer-6) + var(--spacer-1) + var(--spacer-1));
+    z-index: 1001;
+    display: none;
+    gap: var(--spacer-05);
+    background: var(--surface-2);
+    border: 1px solid var(--surface-3);
+    border-radius: var(--border-radius-s);
+    padding: var(--spacer-05);
+    box-shadow: var(--shadow-d);
+
+    /* Show on mobile when both panels exist */
+    @media (max-width: 768px) {
+        display: flex;
+    }
 }
 
-.c-panel-context-backdrop {
+.c-panel-switcher-tab {
+    background: transparent;
+    border: none;
+    border-radius: var(--border-radius-xs);
+    color: var(--surface-6);
+    cursor: pointer;
+    font-size: var(--font-xs);
+    font-weight: 500;
+    padding: var(--spacer-05) var(--spacer-1);
+    transition: all 0.2s ease;
+
+    &:hover {
+        background: var(--surface-3);
+        color: var(--surface-8);
+    }
+
+    &.is-active {
+        background: var(--surface-4);
+        color: var(--surface-8);
+    }
+
+    &:active {
+        transform: scale(0.95);
+    }
+}
+
+/* Unified mobile backdrop overlay */
+.c-panel-backdrop {
     position: fixed;
     top: 0;
     left: 0;

--- a/packages/common/components/ui/panel-context/panel-context.css
+++ b/packages/common/components/ui/panel-context/panel-context.css
@@ -1,5 +1,5 @@
 .c-panel-context {
-    border-left: 1px solid var(--surface-1);
+    border-right: 1px solid var(--surface-1);
     box-shadow: 0 0 var(--spacer-2) var(--spacer-1) oklch(from var(--surface-0) l c h / 0.4);
     display: flex;
     flex-direction: column;
@@ -97,18 +97,18 @@
         }
     }
 
-    /* Mobile styles - overlay panel */
+    /* Mobile styles - overlay panel (slides from left like PanelMenu) */
     @media (max-width: 768px) {
         position: fixed;
         top: 0;
-        right: 0;
-        z-index: 1000;
+        left: 0;
+        z-index: 1001;
         width: 280px;
         max-width: 85vw;
         transition: transform 0.3s ease-in-out;
 
         /* Always hide panel by default on mobile */
-        transform: translateX(100%);
+        transform: translateX(-100%);
         visibility: hidden;
     }
 }
@@ -124,7 +124,7 @@
 /* Ensure collapsed panel is always hidden on mobile - explicit selector outside nesting for production */
 @media (max-width: 768px) {
     .c-panel-context.collapsed {
-        transform: translateX(100%);
+        transform: translateX(-100%);
         visibility: hidden;
     }
 }


### PR DESCRIPTION
Unify mobile panel toggles and move PanelContext to the left to implement a common mobile UX pattern for navigating between the menu and context panels.

---
<a href="https://cursor.com/background-agent?bcId=bc-34ec7503-0edf-46a1-ba84-4a802155a60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34ec7503-0edf-46a1-ba84-4a802155a60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

