### PR TITLE
Set default login channel

### DIFF
--- a/packages/pyrite/src/components/main/main.tsx
+++ b/packages/pyrite/src/components/main/main.tsx
@@ -142,6 +142,23 @@ export const Main = () => {
             if (isAuthenticated && hasPermission) {
                 notifier.notify({message: 'Login successful', type: 'info'})
                 ws.connect()
+                
+                // Try to route to default channel
+                try {
+                    const defaultChannelResponse = await api.get('/api/channels/default')
+                    if (defaultChannelResponse?.channel?.slug) {
+                        // Set active channel in state and route to default channel
+                        $s.chat.activeChannelSlug = defaultChannelResponse.channel.slug
+                        // Route to default channel after a brief delay to ensure WebSocket is connected
+                        setTimeout(() => {
+                            route(`/channels/${defaultChannelResponse.channel.slug}`)
+                        }, 100)
+                    }
+                } catch(error) {
+                    // If getting default channel fails, just continue without redirecting
+                    logger.debug('[Login] Could not get default channel:', error)
+                }
+                
                 // Success
                 return null
             }

--- a/packages/pyrite/src/components/settings/tabs/channels.tsx
+++ b/packages/pyrite/src/components/settings/tabs/channels.tsx
@@ -1,4 +1,4 @@
-import {FieldText, Button} from '@garage44/common/components'
+import {FieldCheckbox, FieldText, Button} from '@garage44/common/components'
 import {useEffect, useRef} from 'preact/hooks'
 import {deepSignal} from 'deepsignal'
 import {api, notifier} from '@garage44/common/app'
@@ -11,6 +11,7 @@ export default function TabChannels() {
         editing: null as number | null,
         formData: {
             description: '',
+            is_default: false,
             name: '',
             slug: '',
         },
@@ -43,11 +44,12 @@ export default function TabChannels() {
         try {
             const newChannel = await api.post('/api/channels', {
                 description: state.formData.description,
+                is_default: state.formData.is_default,
                 name: state.formData.name,
                 slug: state.formData.slug,
             })
             state.channels = [...state.channels, newChannel]
-            state.formData = {description: '', name: '', slug: ''}
+            state.formData = {description: '', is_default: false, name: '', slug: ''}
             notifier.notify({level: 'success', message: 'Channel created and synced with Galene'})
         } catch(error) {
             const message = error instanceof Error ? error.message : 'Failed to create channel'
@@ -59,6 +61,7 @@ export default function TabChannels() {
         try {
             const updated = await api.put(`/api/channels/${channelId}`, {
                 description: state.formData.description,
+                is_default: state.formData.is_default,
                 name: state.formData.name,
                 slug: state.formData.slug,
             })
@@ -66,7 +69,7 @@ export default function TabChannels() {
                 return c.id === channelId ? updated : c
             })
             state.editing = null
-            state.formData = {description: '', name: '', slug: ''}
+            state.formData = {description: '', is_default: false, name: '', slug: ''}
             notifier.notify({level: 'success', message: 'Channel updated and synced with Galene'})
         } catch(error) {
             const message = error instanceof Error ? error.message : 'Failed to update channel'
@@ -92,6 +95,7 @@ export default function TabChannels() {
         state.editing = channel.id
         state.formData = {
             description: channel.description || '',
+            is_default: channel.is_default === 1,
             name: channel.name,
             slug: channel.slug,
         }
@@ -99,7 +103,7 @@ export default function TabChannels() {
 
     const cancelEdit = () => {
         state.editing = null
-        state.formData = {description: '', name: '', slug: ''}
+        state.formData = {description: '', is_default: false, name: '', slug: ''}
     }
 
     return (
@@ -131,6 +135,11 @@ export default function TabChannels() {
                                     model={state.formData.$description}
                                     placeholder='Enter channel description'
                                 />
+                                <FieldCheckbox
+                                    help='Only one channel can be set as default. Setting this will unset any other default channel.'
+                                    label='Set as default channel'
+                                    model={state.formData.$is_default}
+                                />
                                 <div class='actions'>
                                     <Button
                                         icon='plus'
@@ -158,6 +167,11 @@ export default function TabChannels() {
                                         <FieldText
                                             label='Description'
                                             model={state.formData.$description}
+                                        />
+                                        <FieldCheckbox
+                                            help='Only one channel can be set as default. Setting this will unset any other default channel.'
+                                            label='Set as default channel'
+                                            model={state.formData.$is_default}
                                         />
                                         <div class='actions'>
                                             <Button

--- a/packages/pyrite/src/types.ts
+++ b/packages/pyrite/src/types.ts
@@ -5,6 +5,7 @@ export interface Channel {
     created_at: number
     description: string
     id: number
+    is_default: number
     member_count?: number
     name: string
     slug: string


### PR DESCRIPTION
Implement default channel routing to provide a consistent starting point for users after login.

This PR adds an `is_default` flag to channels, ensures only one channel can be marked as default, and updates the login flow to redirect users to this channel if they have access.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cbe9a72-c5f9-40ed-9496-289273d49ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cbe9a72-c5f9-40ed-9496-289273d49ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

