### PR TITLE
Fix deployment 502 bad gateway error

### DIFF
--- a/deploy/malkovich.service
+++ b/deploy/malkovich.service
@@ -11,7 +11,7 @@ Environment="NODE_ENV=production"
 Environment="BUN_ENV=production"
 Environment="PATH=/home/garage44/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Environment="WEBHOOK_SECRET=your-webhook-secret-here"
-ExecStart=/home/garage44/.bun/bin/bun run server -- --port 3032
+ExecStart=/home/garage44/.bun/bin/bun service.ts start --port 3032
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/packages/malkovich/lib/pr-deploy.ts
+++ b/packages/malkovich/lib/pr-deploy.ts
@@ -890,6 +890,8 @@ async function generateSystemdServices(deployment: PRDeployment, packagesToDeplo
         const prDataDir = path.join(deployment.directory, 'data')
         const dbPath = path.join(prDataDir, `${packageName}.db`)
         const configPath = path.join(prDataDir, `.${packageName}rc`)
+        // Use absolute path to service.ts to avoid path resolution issues
+        const serviceTsPath = path.join(workdir, 'service.ts')
 
         const content = `[Unit]
 Description=PR #${deployment.number} ${packageName} service
@@ -905,7 +907,7 @@ Environment="BUN_ENV=production"
 Environment="DB_PATH=${dbPath}"
 Environment="CONFIG_PATH=${configPath}"
 Environment="PATH=/home/garage44/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ExecStart=/home/garage44/.bun/bin/bun service.ts start --port ${port}
+ExecStart=/home/garage44/.bun/bin/bun ${serviceTsPath} start --port ${port}
 Restart=no
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Fix 502 Bad Gateway by correcting the `ExecStart` command in `malkovich.service` to properly parse the port argument.

The `--` separator in the previous `ExecStart` command (`bun run server -- --port 3032`) caused `yargs` to treat `--port 3032` as a positional argument instead of an option. This prevented the service from listening on the specified port, resulting in a 502 Bad Gateway. The updated command directly invokes `service.ts` with the `--port` option, allowing `yargs` to parse it correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-91910da5-0d52-4da6-8d85-1bedda702068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91910da5-0d52-4da6-8d85-1bedda702068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

